### PR TITLE
Landscape support

### DIFF
--- a/css/base-landing.css
+++ b/css/base-landing.css
@@ -13,6 +13,13 @@
 }
 
 /* Global stylesheet */
+
+#container {
+	position: fixed;
+	height: 100%;
+	width: 100%;
+}
+
 #header {
 	box-sizing: border-box;
 }
@@ -43,15 +50,14 @@
 	text-align: center;
 }
 
+
+
 /* Device specific stylesheets */
 /* Phone spec */
-@media only screen and (max-width: 720px) {
+@media only screen and (max-width: 720px) and (orientation: portrait) {
 
 	/* the whole container */
 	#container {
-		position: fixed;
-		height: 100%;
-		width: 100%;
 		display: flex;
 		overflow: hidden;
 		flex-flow: column;
@@ -84,7 +90,6 @@
 	#content {
 		flex: 1;
 		overflow: auto;
-		
 		display: flex;
 		flex-flow: column;
 		justify-content: center;
@@ -99,15 +104,29 @@
 	}
 }
 
-/* PC Spec */
-@media only screen and (min-width: 720px) {
-	
-	/* the whole container */
-	#container {
-		position: fixed;
-		height: 100%;
-		width: 100%;
+
+/* Phone-Landscape spec */
+@media only screen and (max-width: 850px) and (orientation: landscape) {
+
+	#header .nav {
+		position: relative;
+		float: left;
 	}
+
+	.nav li {
+		display: inline-block;
+	}
+
+	/* Footer */
+	#footer {
+		position: absolute;
+		bottom: 0;
+	}
+}
+
+
+/* PC Spec */
+@media only screen and (min-width: 450px){
 	
 	/* Header */
 	#header {
@@ -140,7 +159,7 @@
 		position: relative;
 		float: right;
 	}
-	
+
 	#content {
 		position: absolute;
 		left: 50%;

--- a/css/fonts.css
+++ b/css/fonts.css
@@ -31,7 +31,7 @@
 	letter-spacing: 5px;
 }
 
-@media only screen and (min-width: 825px) {	
+@media only screen and (min-width: 850px) {	
 	/* font sizes */
 	.display1 {
 		font-size: 112px;
@@ -49,7 +49,7 @@
 	}
 }
 
-@media only screen and (max-width: 825px) {
+@media only screen and (max-width: 850px) {
 	/* font sizes */
 	.display1 {
 		font-size: 45px;

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 	<link href="/css/landing.css" type="text/css" rel="stylesheet" />
 		
 	<head>	
+		<meta name="viewport" content="width=device-width,initial-scale=1.0">
 		<title>Macky</title>
 	</head>
 


### PR DESCRIPTION
Adds mobile-friendly landscape support to the page, supporting some phone notches as well. Not tested for Apple's iPhone notch implementation - and in extension, Android phones with big notches.

![image](https://user-images.githubusercontent.com/17867386/63208366-9dec0a00-c105-11e9-9fd2-48e9834835bc.png)

Side effect: there are conflicts between the mobile view and the PC style when both of the media queries match (see picture).

![image](https://user-images.githubusercontent.com/17867386/63208382-d4298980-c105-11e9-866c-943e5ed70ed7.png)
